### PR TITLE
CI

### DIFF
--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -257,7 +257,6 @@ defmodule DartSass do
     cacertfile = CAStore.file_path() |> String.to_charlist()
 
     http_options = [
-      autoredirect: false,
       ssl: [
         verify: :verify_peer,
         cacertfile: cacertfile,
@@ -268,21 +267,22 @@ defmodule DartSass do
       ]
     ]
 
-    case :httpc.request(:get, {url, []}, http_options, []) do
-      {:ok, {{_, 302, _}, headers, _}} ->
-        {'location', download} = List.keyfind(headers, 'location', 0)
-        options = [body_format: :binary]
+    options = [body_format: :binary, headers_as_is: true]
 
-        case :httpc.request(:get, {download, []}, http_options, options) do
-          {:ok, {{_, 200, _}, _, body}} ->
-            body
+    # case :httpc.request(:get, {url, []}, http_options, []) do
+    #   {:ok, {{_, 302, _}, headers, _}} ->
+    #     {'location', download} = List.keyfind(headers, 'location', 0)
 
-          other ->
-            raise "couldn't fetch #{url}: #{inspect(other)}"
-        end
+    case :httpc.request(:get, {url, []}, http_options, options) do
+      {:ok, {{_, 200, _}, _, body}} ->
+        body
 
       other ->
         raise "couldn't fetch #{url}: #{inspect(other)}"
     end
+
+    #   other ->
+    #     raise "couldn't fetch #{url}: #{inspect(other)}"
+    # end
   end
 end

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -257,6 +257,7 @@ defmodule DartSass do
     cacertfile = CAStore.file_path() |> String.to_charlist()
 
     http_options = [
+      autoredirect: false,
       ssl: [
         verify: :verify_peer,
         cacertfile: cacertfile,
@@ -267,11 +268,18 @@ defmodule DartSass do
       ]
     ]
 
-    options = [body_format: :binary]
+    case :httpc.request(:get, {url, []}, http_options, []) do
+      {:ok, {{_, 302, _}, headers, _}} ->
+        {'location', download} = List.keyfind(headers, 'location', 0)
+        options = [body_format: :binary]
 
-    case :httpc.request(:get, {url, []}, http_options, options) do
-      {:ok, {{_, 200, _}, _headers, body}} ->
-        body
+        case :httpc.request(:get, {download, []}, http_options, options) do
+          {:ok, {{_, 200, _}, _, body}} ->
+            body
+
+          other ->
+            raise "couldn't fetch #{url}: #{inspect(other)}"
+        end
 
       other ->
         raise "couldn't fetch #{url}: #{inspect(other)}"

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -267,7 +267,7 @@ defmodule DartSass do
       ]
     ]
 
-    options = [body_format: :binary, cookies: :enabled]
+    options = [body_format: :binary]
 
     case :httpc.request(:get, {url, []}, http_options, options) do
       {:ok, {{_, 200, _}, _headers, body}} ->

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -257,6 +257,7 @@ defmodule DartSass do
     cacertfile = CAStore.file_path() |> String.to_charlist()
 
     http_options = [
+      autoredirect: false,
       ssl: [
         verify: :verify_peer,
         cacertfile: cacertfile,
@@ -267,22 +268,21 @@ defmodule DartSass do
       ]
     ]
 
-    options = [body_format: :binary, headers_as_is: true]
+    case :httpc.request(:get, {url, []}, http_options, []) do
+      {:ok, {{_, 302, _}, headers, _}} ->
+        {'location', download} = List.keyfind(headers, 'location', 0)
+        options = [body_format: :binary]
 
-    # case :httpc.request(:get, {url, []}, http_options, []) do
-    #   {:ok, {{_, 302, _}, headers, _}} ->
-    #     {'location', download} = List.keyfind(headers, 'location', 0)
+        case :httpc.request(:get, {download, []}, http_options, options) do
+          {:ok, {{_, 200, _}, _, body}} ->
+            body
 
-    case :httpc.request(:get, {url, []}, http_options, options) do
-      {:ok, {{_, 200, _}, _, body}} ->
-        body
+          other ->
+            raise "couldn't fetch #{url}: #{inspect(other)}"
+        end
 
       other ->
         raise "couldn't fetch #{url}: #{inspect(other)}"
     end
-
-    #   other ->
-    #     raise "couldn't fetch #{url}: #{inspect(other)}"
-    # end
   end
 end

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -267,7 +267,7 @@ defmodule DartSass do
       ]
     ]
 
-    options = [body_format: :binary]
+    options = [body_format: :binary, cookies: :enabled]
 
     case :httpc.request(:get, {url, []}, http_options, options) do
       {:ok, {{_, 200, _}, _headers, body}} ->

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -278,7 +278,7 @@ defmodule DartSass do
             body
 
           other ->
-            raise "couldn't fetch #{url}: #{inspect(other)}"
+            raise "couldn't fetch #{download}: #{inspect(other)}"
         end
 
       other ->


### PR DESCRIPTION
Requests to download binary release assets from GitHub will respond with a 302 Redirect to an S3 signed URL for the asset proper. The asset URL needs to be requested pristinely, which afaict requires handling the redirect manually.