### PR TITLE
Provide an option for loading the runtime config

### DIFF
--- a/lib/mix/tasks/sass.ex
+++ b/lib/mix/tasks/sass.ex
@@ -17,6 +17,10 @@ defmodule Mix.Tasks.Sass do
   If dart-sass is not installed, it is automatically downloaded.
   Note the arguments given to this task will be appended
   to any configured arguments.
+
+  ## Options
+    * `--runtime-config` - load the runtime configuration before executing
+      command
   """
 
   @shortdoc "Invokes sass with the profile and args"
@@ -25,11 +29,16 @@ defmodule Mix.Tasks.Sass do
 
   @impl true
   def run([profile | args] = all) do
-    if Code.ensure_loaded?(Mix.Tasks.App.Config) do
+    switches = [runtime_config: :boolean]
+    {opts, remaining_args} = OptionParser.parse_head!(args, switches: switches)
+
+    if opts[:runtime_config] do
       Mix.Task.run("app.config")
+    else
+      Application.ensure_all_started(:dart_sass)
     end
 
-    case DartSass.install_and_run(String.to_atom(profile), args) do
+    case DartSass.install_and_run(String.to_atom(profile), remaining_args) do
       0 -> :ok
       status -> Mix.raise("`mix sass #{Enum.join(all, " ")}` exited with #{status}")
     end


### PR DESCRIPTION
Do not load the runtime configuration by default. Instead, provide an
option, `--runtime-config`, for loading the runtime configuration.

This mirrors the configuration in `esbuild`.