### PR TITLE
Adding support for configuring a binary download target

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ config :dart_sass,
 When `mix sass default` is invoked, the task arguments will be appended
 to the ones configured above.
 
+## Specifying Binary Target
+Currently the dart-sass team does not fully support Apple Silicon (M1 processors for example), in order to help stopgap this you can change the binary target DartSass attempts to download & use. Full options available on the [dart-sass releases](https://github.com/sass/dart-sass/releases).
+
+```elixir
+config :dart_sass,
+  version: "1.39.0",
+  binary_download_target: "macos-x64.tar.gz",
+  ...
+```
+
 ## Adding to Phoenix
 
 To add `dart_sass` to an application using Phoenix, you need only four steps.

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -244,7 +244,15 @@ defmodule DartSass do
   end
 
   # Available targets: https://github.com/sass/dart-sass/releases
+  # Can be manually specified for environments like the Apple M1 (for example: macos-x64 instead of aarch64-x64 to use Intel with Rosetta)
   defp target do
+    case Application.fetch_env(:dart_sass, :binary_download_target) do
+      {:ok, target} -> target
+      :error -> guess_target()
+    end
+  end
+
+  defp guess_target do
     case :os.type() do
       {:win32, _} ->
         case :erlang.system_info(:wordsize) * 8 do


### PR DESCRIPTION
Should provide a stopgap for those of us who want to keep moving with Phoenix + Sass!

"Fixes" https://github.com/CargoSense/dart_sass/issues/7
