### PR TITLE
Enabled x86 fallback for "arm" as well.

### DIFF
--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -258,7 +258,7 @@ defmodule DartSass do
         osname = if osname == :darwin, do: :macos, else: osname
 
         arch =
-          if osname == :macos and arch == "aarch64" do
+          if osname == :macos and arch in ["aarch64", "arm"] do
             # Using Rosetta2 for M1 until dart_sass runs native
             "amd64"
           else


### PR DESCRIPTION
This is crazy but I've got to OTP builds here (23 and 24) and one identifies itself as "arm" the other as "aarch64"

* OTP24: `aarch64-apple-darwin20.6.0`
* OTP23: `arm-apple-darwin20.6.0`

to make this fallback work on both I've added "arm" to the list