### PR TITLE
Do not check the platform when custom path is given

### DIFF
--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -120,16 +120,16 @@ defmodule DartSass do
   preceeded by the path to the Dart VM executable.
   """
   def bin_path do
-    platform = platform()
-
     cond do
       env_path = Application.get_env(:dart_sass, :path) ->
         List.wrap(env_path)
 
       Code.ensure_loaded?(Mix.Project) ->
+        platform = platform()
         bin_path(platform, Path.dirname(Mix.Project.build_path()))
 
       true ->
+        platform = platform()
         bin_path(platform, "_build")
     end
   end


### PR DESCRIPTION
Otherwise compilation raises errors on unsupported platforms (FreeBSD in my case). There is no need to check this when providing a custom binary.