### PR TITLE
Depend on inets and ssl

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,17 +24,13 @@ defmodule DartSass.MixProject do
         source_ref: "v#{@version}",
         extras: ["CHANGELOG.md"]
       ],
-      xref: [
-        exclude: [:httpc, :public_key]
-      ],
       aliases: [test: ["sass.install --if-missing", "test"]]
     ]
   end
 
   def application do
     [
-      # inets/ssl may be used by Mix tasks but we should not impose them.
-      extra_applications: [:logger],
+      extra_applications: [:logger, :inets, :ssl],
       mod: {DartSass, []},
       env: [default: []]
     ]


### PR DESCRIPTION
Elixir v1.15 will prune applications from the code path that are not listed as dependencies, so we need to explicitly depend on inets and ssl.