### PR TITLE
Fix charlist warning for Elixir 1.17

### DIFF
--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -345,7 +345,7 @@ defmodule DartSass do
 
     case :httpc.request(:get, {url, []}, http_options, []) do
       {:ok, {{_, 302, _}, headers, _}} ->
-        {'location', download} = List.keyfind(headers, 'location', 0)
+        {~c"location", download} = List.keyfind(headers, ~c"location", 0)
         options = [body_format: :binary]
 
         case :httpc.request(:get, {download, []}, http_options, options) do


### PR DESCRIPTION
Prevents the following warning:

```==> dart_sass
     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 348 │         {'location', download} = List.keyfind(headers, 'location', 0)
     │          ~
     │
     └─ lib/dart_sass.ex:348:10

     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 348 │         {'location', download} = List.keyfind(headers, 'location', 0)
     │                                                        ~
     │
     └─ lib/dart_sass.ex:348:56
```