### PR TITLE
Bump Dart Sass references to v1.77.8; update README, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.7.1 (2024-07-29)
+
+  * Update references to Dart Sass version to use latest `1.77.8` release
+  * Update README to reflect minor version increase to `~> 0.7`, Dart Sass to `1.77.8`, edge Phoenix to `~> 1.7.14`
+  * Fix Warning for elixir 1.17
+
 ## v0.7.0 (2023-06-27)
 
   * Require Elixir v1.11+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.7.1 (2024-07-29)
+## v0.7.1
 
   * Update references to Dart Sass version to use latest `1.77.8` release
   * Update README to reflect minor version increase to `~> 0.7`, Dart Sass to `1.77.8`, edge Phoenix to `~> 1.7.14`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ in dev:
 ```elixir
 def deps do
   [
-    {:dart_sass, "~> 0.6", runtime: Mix.env() == :dev}
+    {:dart_sass, "~> 0.7", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -24,7 +24,7 @@ then it only needs to be a dev dependency:
 ```elixir
 def deps do
   [
-    {:dart_sass, "~> 0.6", only: :dev}
+    {:dart_sass, "~> 0.7", only: :dev}
   ]
 end
 ```
@@ -33,7 +33,7 @@ Once installed, change your `config/config.exs` to pick your
 dart_sass version of choice:
 
 ```elixir
-config :dart_sass, version: "1.61.0"
+config :dart_sass, version: "1.77.8"
 ```
 
 Now you can install dart-sass by running:
@@ -68,7 +68,7 @@ directory, the OS environment, and default arguments to the
 
 ```elixir
 config :dart_sass,
-  version: "1.61.0",
+  version: "1.77.8",
   default: [
     args: ~w(css/app.scss ../priv/static/assets/app.css),
     cd: Path.expand("../assets", __DIR__)
@@ -89,8 +89,8 @@ First add it as a dependency in your `mix.exs`:
 ```elixir
 def deps do
   [
-    {:phoenix, "~> 1.6.0"},
-    {:dart_sass, "~> 0.5", runtime: Mix.env() == :dev}
+    {:phoenix, "~> 1.7.14"},
+    {:dart_sass, "~> 0.7", runtime: Mix.env() == :dev}
   ]
 end
 ```
@@ -100,7 +100,7 @@ compile CSS to the output location `priv/static/assets/app.css`:
 
 ```elixir
 config :dart_sass,
-  version: "1.61.0",
+  version: "1.77.8",
   default: [
     args: ~w(css/app.scss ../priv/static/assets/app.css),
     cd: Path.expand("../assets", __DIR__)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :dart_sass,
-  version: "1.61.0",
+  version: "1.77.8",
   another: [
     args: ["--version"]
   ]

--- a/lib/dart_sass.ex
+++ b/lib/dart_sass.ex
@@ -9,7 +9,7 @@ defmodule DartSass do
   directory and environment:
 
       config :dart_sass,
-        version: "1.61.0",
+        version: "1.77.8",
         default: [
           args: ~w(css/app.scss ../priv/static/assets/app.css),
           cd: Path.expand("../assets", __DIR__)
@@ -87,7 +87,7 @@ defmodule DartSass do
 
   @doc false
   # Latest known version at the time of publishing.
-  def latest_version, do: "1.61.0"
+  def latest_version, do: "1.77.8"
 
   @doc """
   Returns the configured Sass version.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule DartSass.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.7.1"
   @source_url "https://github.com/CargoSense/dart_sass"
 
   def project do


### PR DESCRIPTION
This patch upgrades all references and tests to the most current version of the official Dart Sass library, [v1.77.8](https://github.com/sass/dart-sass/releases/tag/1.77.8) from the most recently supported version, v1.61.0.

This patch also updates the README to refer to the correct minor version to use when installing/referencing this Elixir dart_sass hex package from mix.exs. Additionally it adds a note to the CHANGELOG regarding these changes.