### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "CargoSense/dx-reviewers"
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "CargoSense/elixir-reviewers"


### PR DESCRIPTION
## Description

Adds a Dependabot configuration file with the GitHub Actions and Mix ecosystems set to run on a monthly schedule.

A future addition to this file will configure the Dev Containers ecosystem when that's in place on the project.