### PR TITLE
Add Dev Container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+    "name": "dart_sass",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "elixir:1.17-otp-27-slim",
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+      "ghcr.io/devcontainers/features/common-utils:2": {
+        "installOhMyZsh": false,
+        "installOhMyZshConfig": false
+      },
+      "ghcr.io/devcontainers/features/git:1": {
+        "version": "latest"
+      },
+      "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": ".devcontainer/setup.sh",
+
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+              "EditorConfig.EditorConfig",
+              "JakeBecker.elixir-ls",
+              "jasonnutter.vscode-codeowners"
+            ]
+        }
+    }
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+mix local.hex --force
+mix deps.get


### PR DESCRIPTION
This is a fairly simple Dev Container configuration mostly derived from [the one on CargoSense/compare_chain](https://github.com/CargoSense/compare_chain/tree/main/.devcontainer).

With this setup, I opened the project in VS Code, clicked the "Reopen in Container" navigation toast thing (or invoke the similar command from the command palette), and waited for the build process to complete. On a Terminal prompt within the Dev Container, I successfully ran `MIX_ENV=test mix test` and got no errors!

@mcrumm Without getting in to package code changes or anything, are there additional tools you might expect to have available within the Dev Container? As is, the setup is lightweight which I believe is suitable for this kind of project.